### PR TITLE
Fix crashes when completing a path after ~/ and with an unmatched {

### DIFF
--- a/lua/cmp_path/init.lua
+++ b/lua/cmp_path/init.lua
@@ -54,9 +54,9 @@ source._dirname = function(self, params)
   elseif prefix:match('%./$') then
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   elseif prefix:match('~/$') then
-    return vim.fn.expand('~/' .. dirname), params.offset
+    return vim.fn.resolve(vim.fn.expand('~') .. '/' .. dirname)
   elseif prefix:match('%$[%a_]+/$') then
-    return vim.fn.expand(prefix:match('%$[%a_]+/$') .. dirname)
+    return vim.fn.resolve(vim.fn.getenv(prefix:match('%$([%a_]+)/$')) .. '/' .. dirname)
   elseif prefix:match('/$') then
     local accept = true
     -- Ignore URL components
@@ -157,4 +157,3 @@ source._is_slash_comment = function(_)
 end
 
 return source
-


### PR DESCRIPTION
Happened to me while I was working on a shell script and using curly brace expansion (i.e. `a{b,c}` => `ab ac`), the plugin would crash with `E5108: Error executing lua Vim:E220: Missing }.`. Also I am pretty sure this error can accidentally happen in Python f-strings too. The fix was to not supply user input to `expand()`, which is also done when processing env variables.