### PR TITLE
feat: support relative paths without a leading forward slash

### DIFF
--- a/lua/cmp_path/init.lua
+++ b/lua/cmp_path/init.lua
@@ -1,7 +1,7 @@
 local cmp = require'cmp'
 
 local NAME_REGEX = '\\%([^/\\\\:\\*?<>\'"`\\|]\\)'
-local PATH_REGEX = vim.regex(([[\%(/PAT\+\)*/\zePAT*$]]):gsub('PAT', NAME_REGEX))
+local PATH_REGEX = vim.regex(([[\%([/"\']PAT\+\)*[/"\']\zePAT*$]]):gsub('PAT', NAME_REGEX))
 
 local source = {}
 
@@ -14,7 +14,7 @@ source.new = function()
 end
 
 source.get_trigger_characters = function()
-  return { '/', '.' }
+  return { '/', '.', '"', '\'' }
 end
 
 source.get_keyword_pattern = function()
@@ -56,7 +56,7 @@ source._dirname = function(self, params)
   if prefix:match('%.%./$') then
     return vim.fn.resolve(buf_dirname .. '/../' .. dirname)
   end
-  if prefix:match('%./$') then
+  if (prefix:match('%./$') or prefix:match('"$') or prefix:match('\'$')) then
     return vim.fn.resolve(buf_dirname .. '/' .. dirname)
   end
   if prefix:match('~/$') then


### PR DESCRIPTION
```
feat: support relative paths without a leading forward slash

This patch adds support for triggering path completion on `"` and `'`
(double and single quotes), limited to relative paths that start without
a leading forward slash.

closes #10
```