### PR TITLE
Fix path completions break after second /

### DIFF
--- a/lua/cmp_path/init.lua
+++ b/lua/cmp_path/init.lua
@@ -1,7 +1,7 @@
 local cmp = require'cmp'
 
 local NAME_REGEX = '\\%([^/\\\\:\\*?<>\'"`\\|]\\)'
-local PATH_REGEX = vim.regex(([[\%(PAT\+\)*\zePAT*$]]):gsub('PAT', NAME_REGEX))
+local PATH_REGEX = vim.regex(([[\%(/PAT\+\)*/\zePAT*$]]):gsub('PAT', NAME_REGEX))
 
 local source = {}
 


### PR DESCRIPTION
Signed-off-by: Marcus Heng <marcushwz@gmail.com>

Some users are facing the same problem as stated in this [issue](https://github.com/hrsh7th/cmp-path/issues/23).

I was going through the commits, it seems like the `PATH_REGEX` changes were introduced back in this [PR](https://github.com/hrsh7th/cmp-path/commit/d4544fc96519815709d0170bac67936921cb31e2), so I am not 100% sure after rolling back to the original `PATH_REGEX`, the feature introduced by the PR still works or not.