### PR TITLE
lua: ensure directories have trailing slash

### DIFF
--- a/lua/cmp_path/init.lua
+++ b/lua/cmp_path/init.lua
@@ -143,7 +143,6 @@ source._candidates = function(_, dirname, include_hidden, callback)
     }
     if fs_type == 'directory' then
       item.kind = cmp.lsp.CompletionItemKind.Folder
-      item.word = name
       item.label = name .. '/'
       item.insertText = name .. '/'
     end


### PR DESCRIPTION
Currently, when autocompleting a file that is a directory, the text that
is actually completed in the cmdline has no trailing slash. This makes
it annoying to type file paths as the text in the label does not match
the text that is actually inserted. This commit fixes the behavior by
ensuring that inserted text always has a trailing slash.

Note: although this achieves the desired results, I'm not sure if this
approach is semantically correct; please advise.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

Before:
![image](https://user-images.githubusercontent.com/20484159/149759810-5d0b98f5-6e61-4251-95e3-4e0a031d80b1.png)

After:
![image](https://user-images.githubusercontent.com/20484159/149759705-1acd9c11-04ed-444c-b747-3167eccdf2cc.png)
