### PR TITLE
added option to change the base dir for relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ cmp.setup({
 _Default:_ `false`
 
 Specify if completed directory names should include a trailing slash. Enabling this option makes this source behave like Vim's built-in path completion.
+
+### get_cwd (type: function)
+
+_Default:_ returns the current working directory of the current buffer
+
+Specifies the base directory for relative paths.


### PR DESCRIPTION
Hi,

I'm using project.nvim and it changes the current working directory accordingly, for each project.
However, the path completion ignores the current working directory and always uses the cwd of the current buffer for relative paths.

I noticed there is already an issue for this: !21

Since this is my first time writing lua, feedback would be highly appreciated.

Thanks for feedback and for the great project