### PR TITLE
feat: Allow get_cwd() function to return an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Specify if directory names in the completion menu should include a trailing slas
 _Default:_ returns the current working directory of the current buffer
 
 Specifies the base directory for relative paths.
+
+If a _table_ is returned, all directories are looked up in order.


### PR DESCRIPTION
This _P.R_ allows `get_cwd()` function to return an array.

My motivation is to use a custom `get_cwd()` function such as

```lua
get_cwd = function(params)
  return {
    vim.fn.expand(('#%d:p:h'):format(params.context.bufnr)), -- default value
    vim.fn.getcwd(),
  }
end
```
that allows to have completion for both the _buffer cwd_ (current behavior) and for the _cwd where neovim was opened_ for _relative paths_.

I've tried to handle the _`get_cwd()` returns a string_ case not to break user configurations with _custom `get_cwd()`_.
So, no backward incompatibility is expected.

:warning:  I'm a real beginner in `lua` so the code may be far from optimal :student: 