### PR TITLE
feat: add max_traversed_entries option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ Specify if directory names in the completion menu should include a trailing slas
 _Default:_ returns the current working directory of the current buffer
 
 Specifies the base directory for relative paths.
+
+### max_traverse_entries (type: number)
+
+_Default:_ `nil`
+
+The maximum count of entries in a directory will this source traverse before returning candidates.
+
+Some directories may have a large number of entries. Users, who prefer to have a time-bounded feedback over completeness, may limit the number of entries this plugin fetches with this option.
+
+If this option is set to nil, there's no effective limit.


### PR DESCRIPTION
At my work, we have a huge monorepo with a directory with over 70k entries. This plugin, being synchronous, was blocking Neovim for tens of seconds.

This option should be universally useful to just time-box any search done by this plugin. I don't think it makes sense to leave this search unbounded as people expect interactivity from Neovim.

Perhaps, some change of API will make it possible to make search more optimal (e.g., a batch fetch), but even than a limit to how many entries Neovim has to process is relevant.