### PR TITLE
add a `loaded_*` variable in case `after/plugin/` sourced twice

### DIFF
--- a/after/plugin/cmp_path.lua
+++ b/after/plugin/cmp_path.lua
@@ -1,1 +1,6 @@
+if vim.g.loaded_cmp_path then
+    return
+end
+vim.g.loaded_cmp_path = true
+
 require('cmp').register_source('path', require('cmp_path').new())


### PR DESCRIPTION
In my stupid neovim setup, I use lazy.nvim with `loadplugins = true`, to use packages as well. Yet problems is plugins managed by lazy will sourced twice, so for plugins like cmp-path, I got the exact same complete entries, twice. 

The PR is mainly for discussion (I guess ?), maybe there is a better solution, or just say bye to packages. 

Thanks
